### PR TITLE
fix program list update bug

### DIFF
--- a/src/app/api/program-dates/route.js
+++ b/src/app/api/program-dates/route.js
@@ -1,5 +1,7 @@
 import initiate from "@/common/parse-initialize";
 
+export const revalidate = 0;
+
 export async function GET(request) {
   const myParse = initiate();
   const query= new myParse.Query("Program");

--- a/src/app/api/program-dates/route.js
+++ b/src/app/api/program-dates/route.js
@@ -1,5 +1,6 @@
 import initiate from "@/common/parse-initialize";
 
+//this is needed so that a cached version of the list is not used. 
 export const revalidate = 0;
 
 export async function GET(request) {


### PR DESCRIPTION
before, /api/program-dates wouldn't update, it would always use a cache. update a segment config option called "revalidate" by setting it to 0